### PR TITLE
Fix/records

### DIFF
--- a/examples/negative/name_errors/L3/8_non_local_var_proc.ob
+++ b/examples/negative/name_errors/L3/8_non_local_var_proc.ob
@@ -1,13 +1,13 @@
 MODULE NonLocalVarProc;
 
 PROCEDURE FOO;
-  VAR x: INTEGER;
-
-  PROCEDURE BAR;
-    BEGIN
-      x := 42;
-    END BAR;
   
+  PROCEDURE BAR;
+    VAR x: INTEGER;
+    BEGIN
+    END BAR;
+  BEGIN
+    x := 42;
   END FOO;
 
 END NonLocalVarProc.

--- a/examples/negative/name_errors/L3/run
+++ b/examples/negative/name_errors/L3/run
@@ -16,9 +16,7 @@ JAR=${PathToJar}${ObJar}
 if [ "$1" == "test" ];
 then
   # Build all examples and test that a .c file is NOT generated, as expected
-  # TO DO: add back in "8_non_local_var_proc" to examples array below once
-  #        bug has been resolved (https://github.com/melt-umn/Oberon0/issues/6)
-  declare -a examples=("6_duplicate_procs")
+  declare -a examples=("6_duplicate_procs" "8_non_local_var_proc")
   declare r=0
    for file in ${examples[@]}
     do

--- a/examples/positive/L4/run
+++ b/examples/positive/L4/run
@@ -16,9 +16,7 @@ JAR=${PathToJar}${ObJar}
 if [ "$1" == "test" ];
 then
   # Build all examples and test that a .c file is generated as expected
-  # TO DO: add in "record" to examples array below once record declaration
-  #        bug has been resolved. (https://github.com/melt-umn/Oberon0/issues/4)
-  declare -a examples=("array_type" "array_var" "const_len_array"
+  declare -a examples=("array_type" "array_var" "const_len_array" "record"
                        "Sample" "typed_array_in_proc")
   declare r=0
    for file in ${examples[@]}

--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/dataStructures/typeChecking/Expr.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/dataStructures/typeChecking/Expr.sv
@@ -27,9 +27,16 @@ e::LExpr ::= array::LExpr index::Expr
 aspect production fieldAccess
 e::LExpr ::= rec::LExpr fld::Name
 {
-  {- Name will want to look up field names, which requires doing enough
-     type checking to determine the type of `rec`.  We use the threading
-     of `env` and `newEnv` to create the new env.
+  {- Name will want to look up field names, which requires doing
+     enough type checking to determine the type of `rec`.  We use the
+     threading of `env` and `newEnv` to create the new env.  By giving
+     `fld` the correct environment we prevent it from generating
+     spurious error messages for undeclared names.  This analysis is
+     done below in the `e.type` and `e.errors` attributes.  Another
+     possible solution is to just define `type` and `errors` on `e`
+     using the values on `fld`.  But I did not want to change this
+     file too much since it is part of the LDTA 2011 tool challenge
+     and we may discuss the current equations somewhere.
   -}
   fld.env =
     case rec.type of

--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/dataStructures/typeChecking/Expr.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/dataStructures/typeChecking/Expr.sv
@@ -27,6 +27,17 @@ e::LExpr ::= array::LExpr index::Expr
 aspect production fieldAccess
 e::LExpr ::= rec::LExpr fld::Name
 {
+  {- Name will want to look up field names, which requires doing enough
+     type checking to determine the type of `rec`.  We use the threading
+     of `env` and `newEnv` to create the new env.
+  -}
+  fld.env =
+    case rec.type of
+    | recordType(decls,_) -> 
+          (decorate new(decls) with {env = emptyEnv();}).newEnv
+    | _ -> emptyEnv()
+    end;
+
   e.type =
     case rec.type of
     | recordType(decls,_) -> case lookup(fld.name, decls.vars) of


### PR DESCRIPTION
This closes #4 . The bug is resolved by providing a fld::Name with the appropriate record environment if it exists. Eric has added a doc comment describing this fix in grammars/edu.umn.cs.melt.Oberon0/constructs/dataStructures/typeChecking/Expr.sv.