### PR TITLE
Remove uses of autocopy from Oberon0

### DIFF
--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/controlFlow/abstractSyntax/Case.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/controlFlow/abstractSyntax/Case.sv
@@ -26,15 +26,15 @@ synthesized attribute caseTranslation<a> :: a;
 {--
  - The expression under scrutiny by the CASE statement.
  -}
-autocopy attribute caseExpr :: Expr;
+inherited attribute caseExpr :: Expr;
 {--
  - If this case is not satisfied, what to try next.
  -}
-autocopy attribute caseNext :: Stmt;
+inherited attribute caseNext :: Stmt;
 
 nonterminal Cases with location, env, errors, pp, caseTranslation<Stmt>, caseExpr, caseNext;
 
-propagate errors on Cases;  --T2
+propagate errors, caseExpr, caseNext on Cases;  --T2
 
 abstract production caseOne
 cs::Cases ::= c::Case
@@ -60,7 +60,7 @@ cs::Cases ::= c::Case rest::Cases
 
 nonterminal Case with location, env, errors, pp, caseTranslation<Stmt>, caseExpr, caseNext;
 
-propagate errors on Case;  --T2
+propagate errors, caseExpr, caseNext on Case;  --T2
 
 abstract production caseClause
 c::Case ::= cls::CaseLabels s::Stmt
@@ -79,7 +79,7 @@ c::Case ::= s::Stmt
 
 nonterminal CaseLabels with location, env, errors, pp, caseTranslation<Expr>, caseExpr;
 
-propagate errors on CaseLabels;  --T2
+propagate errors, caseExpr on CaseLabels;  --T2
 
 abstract production oneCaseLabel
 cls::CaseLabels ::= cl::CaseLabel
@@ -98,7 +98,7 @@ cls::CaseLabels ::= cl::CaseLabel rest::CaseLabels
 
 nonterminal CaseLabel with location, env, errors, pp, caseTranslation<Expr>, caseExpr;
 
-propagate errors on CaseLabel;  --T2
+propagate errors, caseExpr on CaseLabel;  --T2
 
 abstract production caseLabel
 cl::CaseLabel ::= e::Expr

--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/controlFlow/abstractSyntax/Case.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/controlFlow/abstractSyntax/Case.sv
@@ -8,7 +8,7 @@ s::Stmt ::= e::Expr cs::Cases
     cs.pp, pp:line(),
     pp:text("END")]);
 
-  propagate errors;  --T2
+  propagate errors, env;  --T2
 
   cs.caseExpr = e;
   cs.caseNext = skip(location=cs.location);
@@ -34,7 +34,7 @@ inherited attribute caseNext :: Stmt;
 
 nonterminal Cases with location, env, errors, pp, caseTranslation<Stmt>, caseExpr, caseNext;
 
-propagate errors, caseExpr, caseNext on Cases;  --T2
+propagate errors, caseExpr, caseNext, env on Cases;  --T2
 
 abstract production caseOne
 cs::Cases ::= c::Case
@@ -60,7 +60,7 @@ cs::Cases ::= c::Case rest::Cases
 
 nonterminal Case with location, env, errors, pp, caseTranslation<Stmt>, caseExpr, caseNext;
 
-propagate errors, caseExpr, caseNext on Case;  --T2
+propagate errors, caseExpr, caseNext, env on Case;  --T2
 
 abstract production caseClause
 c::Case ::= cls::CaseLabels s::Stmt
@@ -79,7 +79,7 @@ c::Case ::= s::Stmt
 
 nonterminal CaseLabels with location, env, errors, pp, caseTranslation<Expr>, caseExpr;
 
-propagate errors, caseExpr on CaseLabels;  --T2
+propagate errors, caseExpr, env on CaseLabels;  --T2
 
 abstract production oneCaseLabel
 cls::CaseLabels ::= cl::CaseLabel
@@ -98,7 +98,7 @@ cls::CaseLabels ::= cl::CaseLabel rest::CaseLabels
 
 nonterminal CaseLabel with location, env, errors, pp, caseTranslation<Expr>, caseExpr;
 
-propagate errors, caseExpr on CaseLabel;  --T2
+propagate errors, caseExpr, env on CaseLabel;  --T2
 
 abstract production caseLabel
 cl::CaseLabel ::= e::Expr

--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/controlFlow/abstractSyntax/ForLoop.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/controlFlow/abstractSyntax/ForLoop.sv
@@ -30,7 +30,7 @@ s::Stmt ::= id::Name lower::Expr upper::Expr step::Expr body::Stmt
     pp:text("DONE")]);
 
   --T2-start
-  propagate errors;
+  propagate errors, env;
 
   s.errors <- case lookupValue(id.name, s.env) of
               | just(constDecl(_,_)) -> [err(s.location, "FOR loop variable references a constant, not a variable")]

--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/dataStructures/abstractSyntax/Expr.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/dataStructures/abstractSyntax/Expr.sv
@@ -6,7 +6,7 @@ e::LExpr ::= array::LExpr index::Expr
 {
   e.pp = pp:cat(array.pp, pp:brackets(index.pp));
   
-  propagate errors;  --T2
+  propagate errors, env;  --T2
   e.evalConstInt = nothing();  --T2
 }
 
@@ -15,7 +15,7 @@ e::LExpr ::= rec::LExpr fld::Name
 {
   e.pp = pp:ppConcat([rec.pp, pp:text("."), fld.pp]);
   
-  propagate errors;  --T2
+  propagate errors, env;  --T2
   e.evalConstInt = nothing();  --T2
 }
 

--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/dataStructures/abstractSyntax/TypeExpr.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/dataStructures/abstractSyntax/TypeExpr.sv
@@ -13,7 +13,7 @@ t::TypeExpr ::= e::Expr ty::TypeExpr
 {
   t.pp = pp:ppConcat([pp:text("ARRAY "), e.pp, pp:text(" OF "), ty.pp]);
   
-  propagate errors;  --T2
+  propagate errors, env;  --T2
 }
 
 abstract production recordTypeExpr

--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/procedures/abstractSyntax/Declarations.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/procedures/abstractSyntax/Declarations.sv
@@ -25,6 +25,7 @@ d::Decl ::= id::Name t::TypeExpr
    d.individualDcls := [d];
    d.vars := [pair(id.name, d)];
    d.newEnv = addDefs(valueDef(id.name, d), d.env);
+   propagate env;
   --T2-end
   
   forwards to varDecl(id, t, location=d.location);
@@ -39,6 +40,7 @@ d::Decl ::= id::Name t::TypeExpr
    d.individualDcls := [d];
    d.vars := [pair(id.name, d)];
    d.newEnv = addDefs(valueDef(id.name, d), d.env);
+   propagate env;
   --T2-end
 
   forwards to varDecl(id, t, location=d.location);

--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/procedures/abstractSyntax/ProcedureDcl.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/procedures/abstractSyntax/ProcedureDcl.sv
@@ -13,8 +13,10 @@ exports edu:umn:cs:melt:Oberon0:constructs:procedures:typeChecking
  - * nothing() indicates it's directly in the Module, rather than a specific
  -   procedure.
  -}
-autocopy attribute enclosingProcedure :: Maybe<Decorated Decl>   --T2
+inherited attribute enclosingProcedure :: Maybe<Decorated Decl>   --T2
   occurs on Decl, Module, Stmt;  --T2
+
+propagate enclosingProcedure on Stmt;
 
 abstract production procDecl
 d::Decl ::= id::Name formals::Decl locals::Decl s::Stmt endid::Name
@@ -80,6 +82,7 @@ d::Decl ::= d1::Decl d2::Decl
   local procs :: [Decorated Decl] = filter(isProcDcl, d.individualDcls);
 --  production attribute pppieces :: String with ++; -- from seqDecl
   pppieces <- map((.pp), procs);
+  propagate enclosingProcedure;
 }
 
 {--

--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/procedures/abstractSyntax/Stmt.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/procedures/abstractSyntax/Stmt.sv
@@ -2,7 +2,7 @@ grammar edu:umn:cs:melt:Oberon0:constructs:procedures:abstractSyntax;
 
 nonterminal Exprs with location, pp, env, errors;
 
-propagate errors on Exprs;  --T2
+propagate errors, env on Exprs;  --T2
 
 abstract production callDispatch
 s::Stmt ::= f::Name a::Exprs
@@ -22,7 +22,7 @@ s::Stmt ::= f::Name a::Exprs
 {
   s.pp = pp:ppConcat([f.pp, pp:parens(a.pp)]);
   
-  propagate errors;  --T2
+  propagate env, errors;  --T2
 }
 
 
@@ -48,17 +48,20 @@ s::Stmt ::= f::Name e::Exprs
 {
   s.pp = pp:ppConcat([pp:text("Read"), pp:parens(e.pp)]);
   s.errors := e.errors;  --T2
+  propagate env;
 }
 abstract production writeCall
 s::Stmt ::= f::Name e::Exprs
 {
   s.pp = pp:ppConcat([pp:text("Write"), pp:parens(e.pp)]);
   s.errors := e.errors;  --T2
+  propagate env;
 }
 abstract production writeLnCall
 s::Stmt ::= f::Name e::Exprs
 {
   s.pp = pp:text("WriteLn");
   s.errors := e.errors;  --T2
+  propagate env;
 }
 

--- a/grammars/edu.umn.cs.melt.Oberon0/constructs/procedures/typeChecking/Stmt.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/constructs/procedures/typeChecking/Stmt.sv
@@ -39,7 +39,9 @@ inherited attribute paramsKnown :: Maybe<[Pair<String  Decorated Decl>]> occurs 
 {--
  - The name of the procedure being called, given to the parameter list for error reporting.
  -}
-autocopy attribute procName :: Decorated Name occurs on Exprs;
+inherited attribute procName :: Decorated Name occurs on Exprs;
+
+propagate procName on Exprs;
 
 aspect production nilExprs
 es::Exprs ::=
@@ -51,7 +53,6 @@ es::Exprs ::=
     | just(_::_) -> [err(es.procName.location, "Insufficient parameters supplied to procedure call " ++ es.procName.name)]
     end;
 }
-
 
 aspect production consExprs
 es::Exprs ::= e::Expr rest::Exprs
@@ -76,6 +77,7 @@ es::Exprs ::= e::Expr rest::Exprs
     | just([]) -> nothing()
     | just(_::t) -> just(t)
     end;
+
 }
 
 aspect production readCall

--- a/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/AbstractSyntax.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/AbstractSyntax.sv
@@ -10,6 +10,6 @@ option edu:umn:cs:melt:Oberon0:constructs:procedures;
  - Environments information.
  - See Env.sv for an explanation of why this is Decorated.
  -}
-autocopy attribute env :: Decorated Env;  --T2
+inherited attribute env :: Decorated Env;  --T2
 
 

--- a/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/Declarations.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/Declarations.sv
@@ -176,12 +176,15 @@ synthesized attribute idVarDecls :: Decl;  --T2
 {--
  - The type of each of the identifiers.
  -}
-autocopy attribute idVarDeclTypeExpr :: TypeExpr;  --T2
+inherited attribute idVarDeclTypeExpr :: TypeExpr;  --T2
+propagate idVarDeclTypeExpr on IdList;
+
 {--
  - The kind of declaration. Here, only varDecl. But, the procedure
  - extension will also have "by value" and "by reference" decls as well.
  -}
-autocopy attribute idVarDeclProd :: (Decl ::= Name TypeExpr Location);  --T2
+inherited attribute idVarDeclProd :: (Decl ::= Name TypeExpr Location);  --T2
+propagate idVarDeclProd on IdList;
 
 abstract production idListOne
 ids::IdList ::= id::Name

--- a/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/Declarations.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/Declarations.sv
@@ -17,6 +17,7 @@ synthesized attribute newEnv :: Decorated Env;  --T2
 monoid attribute vars :: [Pair<String Decorated Decl>];  --T2
 
 propagate vars on Decl;
+propagate env on Decl excluding seqDecl;
 
 {--
  - Lines up all decls by their left edge.
@@ -161,6 +162,8 @@ d::Decl ::= ids::IdList t::TypeExpr
   --T2-end
 
   forwards to ids.idVarDecls;
+
+  propagate env;
 }
 
 

--- a/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/Expr.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/Expr.sv
@@ -14,7 +14,7 @@ nonterminal LExpr with location, pp,
  -}
 synthesized attribute evalConstInt :: Maybe<Integer>;  --T2
 
-propagate errors on Expr, LExpr;  -- T2
+propagate errors, env on Expr, LExpr;  -- T2
 
 abstract production idAccess
 e::LExpr ::= id::Name

--- a/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/Name.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/Name.sv
@@ -3,6 +3,8 @@ grammar edu:umn:cs:melt:Oberon0:core:abstractSyntax;
 nonterminal Name with location, pp,
   env, errors, lookupName, name; --T2
 
+propagate env on Name;
+
 {--
  - Focus most of the name-lookup code on names themselves.
  - This attribute is the result of looking up the name in the environment.
@@ -33,6 +35,8 @@ n::Name ::= s::String
 
 nonterminal TypeName with location, pp,
   env, errors, lookupName, name;  --T2
+
+propagate env on TypeName;
 
 abstract production typeName
 n::TypeName ::= s::String

--- a/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/Stmt.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/Stmt.sv
@@ -3,7 +3,7 @@ grammar edu:umn:cs:melt:Oberon0:core:abstractSyntax;
 nonterminal Stmt with location, pp,
   env, errors;  --T2
 
-propagate errors on Stmt;  --T2
+propagate errors, env on Stmt;  --T2
 
 abstract production seqStmt
 s::Stmt ::= s1::Stmt s2::Stmt

--- a/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/TypeExpr.sv
+++ b/grammars/edu.umn.cs.melt.Oberon0/core/abstractSyntax/TypeExpr.sv
@@ -2,7 +2,7 @@ grammar edu:umn:cs:melt:Oberon0:core:abstractSyntax;
 
 nonterminal TypeExpr with location, pp, env, errors;
 
-propagate errors on TypeExpr;
+propagate errors, env on TypeExpr;
 
 abstract production nominalTypeExpr
 t::TypeExpr ::= id::TypeName


### PR DESCRIPTION
Replaces all autocopy attributes with inherited attributes and adds propagate declarations as needed. I'm not sure if I am missing anything but examples work as expected -- there are probably other improvements that could be made too.